### PR TITLE
Don't run dialyxir at runtime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Telemetry.MixProject do
     [
       {:ex_doc, "~> 0.19", only: :docs},
       {:erlang_pmp, "~> 0.1", only: :profile},
-      {:dialyxir, "~> 1.0.0-rc.1", only: :test}
+      {:dialyxir, "~> 1.0.0-rc.1", only: :test, runtime: false}
     ]
   end
 


### PR DESCRIPTION
When I run `mix test` on the repo, I get the following warning:
```
  Warning: the `dialyxir` application's start function was called, which likely means you
  did not add the dependency with the `runtime: false` flag. This is not recommended because
  it will mean that unnecessary applications are started, and unnecessary applications are most
  likely being added to your PLT file, increasing build time.
  Please add `runtime: false` in your `mix.exs` dependency section e.g.:
  {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
```

This PR simply tells the application to not start dialyxir at runtime so that when running the tests, it won't try to start up the dialyxir application unnecessarily.