### PR TITLE
Adding &measure/3 functionality

### DIFF
--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -95,6 +95,18 @@ defmodule Telemetry do
   end
 
   @doc """
+  Calls a function and emits the given event with the execution time in microseconds.
+
+  The given function's result is returned.
+  """
+  @spec measure(event_name, event_metadata, function) :: any
+  def measure(event_name, event_metadata, fun) do
+    {elapsed, result} = :timer.tc(fun)
+    execute(event_name, elapsed, event_metadata)
+    result
+  end
+
+  @doc """
   Returns all handlers attached to events with given prefix.
 
   Handlers attached to many events at once using `attach_many/5` will be listed once for each

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -213,4 +213,22 @@ defmodule TelemetryTest do
       assert [] == Telemetry.list_handlers(event)
     end
   end
+
+  test "measure emits the given event", %{handler_id: handler_id} do
+    event = [:foo, :bar]
+    config = %{send_to: self()}
+    metadata = %{some: :metadata}
+    Telemetry.attach(handler_id, event, TestHandler, :echo_event, config)
+
+    Telemetry.measure(event, metadata, fn -> :timer.sleep(5) end)
+
+    value =
+      receive do
+        {:event, ^event, val, ^metadata, ^config} -> val
+      after
+        500 -> flunk("Expected event not received!")
+      end
+
+    assert is_integer(value) and value > 0
+  end
 end


### PR DESCRIPTION
Would my measure function be a good addition to this library? Without it, it seems that I need to devise my own wrapper to measure how long a function or block of code takes to execute. Isn't this a very common use case?

Maybe there is another tip that might help me on my way?

Thank you!