### PR TITLE
Do not run CI builds on OTP 21.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,8 @@ workflows:
   build_and_test:
     jobs:
       - telemetry/build_and_test:
-          name: "otp-21.2"
-          version: "21.2-alpine"
-      - telemetry/build_and_test:
-          name: "otp-21.1"
-          version: "21.1-alpine"
+          name: "otp-21"
+          version: "21-alpine"
       - telemetry/build_and_test:
           name: "otp-20"
           version: "20-alpine"


### PR DESCRIPTION
I guess there is not need to test on both 21.1 and 21.2, so I'd stick to the most recent release of the 21 major version. We need to spare these precious build seconds 😄 