### PR TITLE
Make empty list an invalid event name

### DIFF
--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -30,7 +30,8 @@ end_per_testcase(_, Config) ->
 bad_event_names(Config) ->
     HandlerId = ?config(id, Config),
     ?assertError(badarg, telemetry:attach(HandlerId, ["some", event], fun ?MODULE:echo_event/4, [])),
-    ?assertError(badarg, telemetry:attach(HandlerId, hello, fun ?MODULE:echo_event/4, [])).
+    ?assertError(badarg, telemetry:attach(HandlerId, hello, fun ?MODULE:echo_event/4, [])),
+    ?assertError(badarg, telemetry:attach(HandlerId, [], fun ?MODULE:echo_event/4, [])).
 
 %% attaching returns error if handler with the same ID already exist
 duplicate_attach(Config) ->


### PR DESCRIPTION
We're only checking if an event is non-empty when attaching since there are no argument checks in `execute/3`.

Closes #29 