### PR TITLE
Event measurements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,9 @@ workflows:
           name: "otp-19"
           version: "19"
           codecov_flag: "otp19"
-          pkg_install_cmd: "apt-get update && apt-get install"
+          pkg_install_cmd: "apt-get update && apt-get install -y"
       - telemetry/build_and_test:
           name: "otp-18"
           version: "18"
           codecov_flag: "otp18"
-          pkg_install_cmd: "apt-get update && apt-get install"
+          pkg_install_cmd: "apt-get update && apt-get install -y"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+The event value has been removed. Now event payload is an arbitrary map. There are two reasons for
+this change:
+
+* It invalidates the notion of some specific property of the event being special;
+* It is up to the consumer of the event to decide what part of the payload is important - the event
+  only indicates that *a thing*  happened.
+
+The `execute/2` API should be now used instead of `execute/3` (previous `execute/2` which set
+metadata as empty map has been removed, this is the only backward-incompatible change). This change
+also means that a handler function now has only three argument (a four-argument version is still
+valid but is deprecated).
+
+### Changed
+
+* `execute/2` now accepts an event name and a map of event data;
+* Handler functions have only 3 arguments now.
+
+### Deprecated
+
+* `:telemetry.execute/3` in favour of `:telemetry.execute/2`. If `execute/3` is used, the event
+  value is merged into metadata map under `:value` key and provided as event data to `execute/2`.
+* 4-argument handler functions. If a 4-argument handler function is invoked, the event value is
+  extracted from event data map from `:value` key, defaulting to `0`.
+
 ## [0.3.0](https://github.com/elixir-telemetry/telemetry/tree/v0.3.0)
 
 This release marks the conversion from Elixir to Erlang. This is a breaking change, but the benefits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-The event value has been removed. Now event payload is an arbitrary map. There are two reasons for
-this change:
-
-* It invalidates the notion of some specific property of the event being special;
-* It is up to the consumer of the event to decide what part of the payload is important - the event
-  only indicates that *a thing*  happened.
-
-The `execute/2` API should be now used instead of `execute/3` (previous `execute/2` which set
-metadata as empty map has been removed, this is the only backward-incompatible change). This change
-also means that a handler function now has only three argument (a four-argument version is still
-valid but is deprecated).
+A single event value has been replaced by a map of measurements. Now it is up to the consumer of the
+event to decide what part of the payload is important. This is useful in cases where event indicates
+that a thing happened but there are many properties describing it. For example, a database query
+event may include total time, decode time, wait time and other measurements.
 
 ### Changed
 
-* `execute/2` now accepts an event name and a map of event data;
-* Handler functions have only 3 arguments now.
+* `execute/3` now accepts a map of measurements instead of event value
 
 ### Deprecated
 
-* `:telemetry.execute/3` in favour of `:telemetry.execute/2`. If `execute/3` is used, the event
-  value is merged into metadata map under `:value` key and provided as event data to `execute/2`.
-* 4-argument handler functions. If a 4-argument handler function is invoked, the event value is
-  extracted from event data map from `:value` key, defaulting to `0`.
+* `:telemetry.execute/3` with an event value in favour of `:telemetry.execute/3` with a map of
+  measurements. If the event value is provided, it is put in a map under a `:value` key and provided
+  as measurements to a handler function.
 
 ## [0.3.0](https://github.com/elixir-telemetry/telemetry/tree/v0.3.0)
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ is sent. The first step is to execute a measurement.
 In Elixir:
 
 ```elixir
-:telemetry.execute([:web, :request, :done], latency, %{request_path: path, status_code: status})
+:telemetry.execute([:web, :request, :done], %{latency: latency, request_path: path, status_code: status})
 ```
 
 In Erlang:
 
 ```erlang
-telemetry:execute([web, request, done], Latency, #{request_path => Path, status_code => Status})
+telemetry:execute([web, request, done], #{latency => Latency, request_path => Path, status_code => Status})
 ```
 
 Then you can create a module to be invoked whenever the event happens.
@@ -36,8 +36,8 @@ In Elixir:
 defmodule LogResponseHandler do
   require Logger
 
-  def handle_event([:web, :request, :done], latency, metadata, _config) do
-    Logger.info("[#{metadata.request_path}] #{metadata.status_code} sent in #{latency}")
+  def handle_event([:web, :request, :done], data, _config) do
+    Logger.info("[#{data.request_path}] #{data.status_code} sent in #{data.latency}")
   end
 end
 ```
@@ -49,8 +49,9 @@ In Erlang:
 
 -include_lib("kernel/include/logger.hrl")
 
-handle_event([web, request, done], Latency, #{path := Path,
-                                              status_code := Status}, _Config) ->
+handle_event([web, request, done], #{latency := Latency,
+                                     path := Path,
+                                     status_code := Status}, _Config) ->
   ?LOG_INFO("[~s] ~p sent in ~p", [Path, Status, Latency]).
 
 ```
@@ -60,13 +61,13 @@ Finally, all you need to do is to attach the module to the executed event.
 In Elixir:
 
 ```elixir
-:telemetry.attach("log-response-handler", [:web, :request, :done], &LogResponseHandler.handle_event/4, nil)
+:telemetry.attach("log-response-handler", [:web, :request, :done], &LogResponseHandler.handle_event/3, nil)
 ```
 
 In Erlang:
 
 ```erlang
-telemetry:attach(<<"log-response-handler">>, [web, request, done], fun log_response_handler:handle_event/4, [])
+telemetry:attach(<<"log-response-handler">>, [web, request, done], fun log_response_handler:handle_event/3, [])
 ```
 
 You might think that it isn't very useful, because you could just as well write a log statement

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -59,7 +59,7 @@
 %%
 %% `handler_id' must be unique, if another handler with the same ID already exists the
 %% `{error, already_exists}' tuple is returned.
-%% See {@link execute/2} to learn how the handlers are invoked.
+%% See {@link execute/3} to learn how the handlers are invoked.
 -spec attach(HandlerId, EventName, Function, Config) -> ok | {error, already_exists} when
       HandlerId :: handler_id(),
       EventName :: event_name(),

--- a/src/telemetry.hrl
+++ b/src/telemetry.hrl
@@ -1,6 +1,6 @@
--record(handler, {id :: telemetry:handler_id(),
+-record(handler, {id :: telemetry:handler_id() | '_',
                   event_name :: telemetry:event_name() | '_',
-                  function   :: telemetry:handler_function(),
+                  function   :: telemetry:handler_function() | '_',
                   config     :: telemetry:handler_config() | '_'}).
 
 -ifdef('OTP_RELEASE').

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -10,8 +10,7 @@ all() ->
      list_handlers, list_for_prefix, detach_on_exception,
      no_execute_detached, no_execute_on_prefix, no_execute_on_specific,
      handler_on_multiple_events, remove_all_handler_on_failure,
-     list_handler_on_many, detach_from_all, old_execute_old_handler,
-     old_execute_new_handler, new_execute_old_handler].
+     list_handler_on_many, detach_from_all, old_execute, default_metadata].
 
 init_per_suite(Config) ->
     application:ensure_all_started(telemetry),
@@ -30,30 +29,31 @@ end_per_testcase(_, Config) ->
 
 bad_event_names(Config) ->
     HandlerId = ?config(id, Config),
-    ?assertError(badarg, telemetry:attach(HandlerId, ["some", event], fun ?MODULE:echo_event/3, [])),
-    ?assertError(badarg, telemetry:attach(HandlerId, hello, fun ?MODULE:echo_event/3, [])),
-    ?assertError(badarg, telemetry:attach(HandlerId, [], fun ?MODULE:echo_event/3, [])).
+    ?assertError(badarg, telemetry:attach(HandlerId, ["some", event], fun ?MODULE:echo_event/4, [])),
+    ?assertError(badarg, telemetry:attach(HandlerId, hello, fun ?MODULE:echo_event/4, [])),
+    ?assertError(badarg, telemetry:attach(HandlerId, [], fun ?MODULE:echo_event/4, [])).
 
 %% attaching returns error if handler with the same ID already exist
 duplicate_attach(Config) ->
     HandlerId = ?config(id, Config),
-    telemetry:attach(HandlerId, [some, event], fun ?MODULE:echo_event/3, []),
+    telemetry:attach(HandlerId, [some, event], fun ?MODULE:echo_event/4, []),
 
     ?assertEqual({error, already_exists},
-                 telemetry:attach(HandlerId, [some, event], fun ?MODULE:echo_event/3, [])).
+                 telemetry:attach(HandlerId, [some, event], fun ?MODULE:echo_event/4, [])).
 
 %% handler is invoked when event it's attached to is emitted
 invoke_handler(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, test, event],
     HandlerConfig = #{send_to => self()},
-    Data = #{some => data},
-    telemetry:attach(HandlerId, Event, fun ?MODULE:echo_event/3, HandlerConfig),
+    Measurements = #{data => 3},
+    Metadata = #{some => metadata},
+    telemetry:attach(HandlerId, Event, fun ?MODULE:echo_event/4, HandlerConfig),
 
-    telemetry:execute(Event, Data),
+    telemetry:execute(Event, Measurements, Metadata),
 
     receive
-        {event, Event, Data, HandlerConfig} ->
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
             ok
     after
         1000 ->
@@ -65,7 +65,7 @@ list_handlers(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, test, event],
     HandlerConfig = #{send_to => self()},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
 
     ?assertMatch([#{id := HandlerId,
@@ -82,7 +82,7 @@ list_for_prefix(Config) ->
     Prefix3 = [a, test],
     Event = [a, test, event],
     HandlerConfig = #{send_to => self()},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
 
     [?assertMatch([#{id := HandlerId,
@@ -97,7 +97,7 @@ list_for_prefix(Config) ->
 detach_on_exception(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, test, event],
-    HandlerFun = fun ?MODULE:raise_on_event/3,
+    HandlerFun = fun ?MODULE:raise_on_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, []),
 
     ?assertMatch([#{id := HandlerId,
@@ -106,7 +106,7 @@ detach_on_exception(Config) ->
                     config := []}],
                  telemetry:list_handlers(Event)),
 
-    telemetry:execute(Event, #{some => data}),
+    telemetry:execute(Event, #{some => 1}, #{some => metadata}),
 
     ?assertEqual([], telemetry:list_handlers(Event)),
 
@@ -118,15 +118,16 @@ no_execute_detached(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, test, event],
     HandlerConfig = #{send_to => self()},
-    Data = #{some => data},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    Measurements = #{data => 3},
+    Metadata = #{some => data},
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
     telemetry:detach(HandlerId),
-    telemetry:execute(Event, Data),
+    telemetry:execute(Event, Measurements, Metadata),
 
     receive
-        {event, Event, Data, HandlerConfig} ->
-            ct:fail(prefix_executed)
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
+            ct:fail(detached_executed)
     after
         300 ->
             ok
@@ -137,15 +138,16 @@ no_execute_on_prefix(Config) ->
     HandlerId = ?config(id, Config),
     Prefix = [a, test],
     Event = [a, test, event],
+    Measurements = #{data => 3},
+    Metadata = #{some => data},
     HandlerConfig = #{send_to => self()},
-    Data = #{some => data},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
 
-    telemetry:execute(Prefix, Data),
+    telemetry:execute(Prefix, Measurements, Metadata),
 
     receive
-        {event, Event, Data, HandlerConfig} ->
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
             ct:fail(prefix_executed)
     after
         300 ->
@@ -157,15 +159,16 @@ no_execute_on_specific(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, test],
     MoreSpecificEvent = [a, test, event, specific],
+    Measurements = #{data => 3},
+    Metadata = #{some => data},
     HandlerConfig = #{send_to => self()},
-    Data = #{some => data},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
 
-    telemetry:execute(MoreSpecificEvent, Data),
+    telemetry:execute(MoreSpecificEvent, Measurements, Metadata),
 
     receive
-        {event, Event, Data, HandlerConfig} ->
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
             ct:fail(specific_executed)
     after
         300 ->
@@ -178,18 +181,19 @@ handler_on_multiple_events(Config) ->
     Event1 = [a, first, event],
     Event2 = [a, second, event],
     Event3 = [a, third, event],
+    Measurements = #{data => 3},
+    Metadata = #{some => data},
     HandlerConfig = #{send_to => self()},
-    Data = #{some => metadata},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
     telemetry:attach_many(HandlerId, [Event1, Event2, Event3], HandlerFun, HandlerConfig),
 
-    telemetry:execute(Event1, Data),
-    telemetry:execute(Event2, Data),
-    telemetry:execute(Event3, Data),
+    telemetry:execute(Event1, Measurements, Metadata),
+    telemetry:execute(Event2, Measurements, Metadata),
+    telemetry:execute(Event3, Measurements, Metadata),
 
     lists:foreach(fun(Event) ->
                           receive
-                              {event, Event, Data, HandlerConfig} ->
+                              {event, Event, Measurements, Metadata, HandlerConfig} ->
                                   ok
                           after
                               300 ->
@@ -203,13 +207,14 @@ remove_all_handler_on_failure(Config) ->
     Event1 = [a, first, event],
     Event2 = [a, second, event],
     Event3 = [a, third, event],
+    Measurements = #{data => 3},
+    Metadata = #{some => data},
     HandlerConfig = #{send_to => self()},
-    Data = #{some => data},
-    HandlerFun = fun ?MODULE:raise_on_event/3,
+    HandlerFun = fun ?MODULE:raise_on_event/4,
 
     telemetry:attach_many(HandlerId, [Event1, Event2, Event3], HandlerFun, HandlerConfig),
 
-    telemetry:execute(Event1, Data),
+    telemetry:execute(Event1, Measurements, Metadata),
 
     lists:foreach(fun(Event) ->
                           ?assertEqual([], telemetry:list_handlers(Event))
@@ -222,7 +227,7 @@ list_handler_on_many(Config) ->
     Event2 = [a, second, event],
     Event3 = [a, third, event],
     HandlerConfig = #{send_to => self()},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
 
     telemetry:attach_many(HandlerId, [Event1, Event2, Event3], HandlerFun, HandlerConfig),
 
@@ -241,7 +246,7 @@ detach_from_all(Config) ->
     Event2 = [a, second, event],
     Event3 = [a, third, event],
     HandlerConfig = #{send_to => self()},
-    HandlerFun = fun ?MODULE:echo_event/3,
+    HandlerFun = fun ?MODULE:echo_event/4,
 
     telemetry:attach_many(HandlerId, [Event1, Event2, Event3], HandlerFun, HandlerConfig),
 
@@ -251,7 +256,7 @@ detach_from_all(Config) ->
                           ?assertEqual([], telemetry:list_handlers(Event))
                   end, [Event1, Event2, Event3]).
 
-old_execute_old_handler(Config) ->
+old_execute(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, first, event],
     Value = 1,
@@ -262,78 +267,35 @@ old_execute_old_handler(Config) ->
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
     telemetry:execute(Event, Value, Metadata),
 
-    ExpectedMetadata = maps:put(value, Value, Metadata),
     receive
-        {event, Event, Value, ExpectedMetadata, HandlerConfig} ->
-            ok
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
+            ?assertEqual(#{value => Value}, Measurements)
     after
         1000 ->
             ct:fail(missing_echo_event)
     end.
 
-old_execute_new_handler(Config) ->
+default_metadata(Config) ->
     HandlerId = ?config(id, Config),
     Event = [a, first, event],
-    Value = 1,
-    Metadata1 = #{some => metadata},
-    Metadata2 = #{value => 3, some => metadata},
-    HandlerConfig = #{send_to => self()},
-    HandlerFun = fun ?MODULE:echo_event/3,
-
-    telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
-    telemetry:execute(Event, Value, Metadata1),
-    telemetry:execute(Event, Value, Metadata2),
-
-    receive
-        {event, Event, Data1, HandlerConfig} ->
-            ?assertEqual(maps:put(value, Value, Metadata1), Data1)
-    after
-        1000 ->
-            ct:fail(missing_echo_event)
-    end,
-    receive
-        {event, Event, Data2, HandlerConfig} ->
-            %% Value argument of execute/3 overrides `value` key in event data.
-            ?assertEqual(maps:put(value, Value, Metadata2), Data2)
-    after
-        1000 ->
-            ct:fail(missing_echo_event)
-    end.
-
-new_execute_old_handler(Config) ->
-    HandlerId = ?config(id, Config),
-    Event = [a, first, event],
-    Data1 = #{value => 1, some => data},
-    Data2 = #{some => data},
+    Measurements = #{data => 3},
     HandlerConfig = #{send_to => self()},
     HandlerFun = fun ?MODULE:echo_event/4,
 
     telemetry:attach(HandlerId, Event, HandlerFun, HandlerConfig),
-    telemetry:execute(Event, Data1),
-    telemetry:execute(Event, Data2),
+    telemetry:execute(Event, Measurements),
 
     receive
-        {event, Event, 1, Metadata1, HandlerConfig} ->
-            ?assertEqual(Metadata1, Data1)
-    after
-        1000 ->
-            ct:fail(missing_echo_event)
-    end,
-    receive
-        {event, Event, 0, Metadata2, HandlerConfig} ->
-            ?assertEqual(Metadata2, Data2)
+        {event, Event, Measurements, Metadata, HandlerConfig} ->
+            ?assertEqual(0, map_size(Metadata))
     after
         1000 ->
             ct:fail(missing_echo_event)
     end.
 
-%%
 
-echo_event(Event, Value, Metadata, #{send_to := Pid} = Config) ->
-    Pid ! {event, Event, Value, Metadata, Config}.
+echo_event(Event, Measurements, Metadata, #{send_to := Pid} = Config) ->
+    Pid ! {event, Event, Measurements, Metadata, Config}.
 
-echo_event(Event, Data, #{send_to := Pid} = Config) ->
-    Pid ! {event, Event, Data, Config}.
-
-raise_on_event(_, _, _) ->
+raise_on_event(_, _, _, _) ->
     throw(got_event).


### PR DESCRIPTION
A single event value has been replaced by a map of measurements. Now it is up to the consumer of the event to decide what part of the payload is important. This is useful in cases where event indicates that a thing happened but there are many properties describing it. 

For example, a database query event may include total time, decode time, wait time and other measurements.