### PR TITLE
Mention performance impact of using function captures

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -64,7 +64,7 @@
 %%
 %% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
 %% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
-%% to achive maximum performance. In other words, avoid using literal anonymous functions
+%% to achieve maximum performance. In other words, avoid using literal anonymous functions
 %% (`fun(...) -> ... end' or `fn ... -> ... end') or local function captures (`fun handle_event/4'
 %% or `&handle_event/4' ) as event handlers.
 -spec attach(HandlerId, EventName, Function, Config) -> ok | {error, already_exists} when
@@ -83,7 +83,7 @@ attach(HandlerId, EventName, Function, Config) ->
 %%
 %% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
 %% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
-%% to achive maximum performance. In other words, avoid using literal anonymous functions
+%% to achieve maximum performance. In other words, avoid using literal anonymous functions
 %% (`fun(...) -> ... end' or `fn ... -> ... end') or local function captures (`fun handle_event/4'
 %% or `&handle_event/4' ) as event handlers.
 -spec attach_many(HandlerId, [EventName], Function, Config) -> ok | {error, already_exists} when

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -64,7 +64,9 @@
 %%
 %% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
 %% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
-%% to achive maximum performance.
+%% to achive maximum performance. In other words, avoid using literal anonymous functions
+%% (`fun(...) -> ... end' or `fn ... -> ... end') or local function captures (`fun handle_event/4'
+%% or `&handle_event/4' ) as event handlers.
 -spec attach(HandlerId, EventName, Function, Config) -> ok | {error, already_exists} when
       HandlerId :: handler_id(),
       EventName :: event_name(),
@@ -81,7 +83,9 @@ attach(HandlerId, EventName, Function, Config) ->
 %%
 %% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
 %% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
-%% to achive maximum performance.
+%% to achive maximum performance. In other words, avoid using literal anonymous functions
+%% (`fun(...) -> ... end' or `fn ... -> ... end') or local function captures (`fun handle_event/4'
+%% or `&handle_event/4' ) as event handlers.
 -spec attach_many(HandlerId, [EventName], Function, Config) -> ok | {error, already_exists} when
       HandlerId :: handler_id(),
       EventName :: event_name(),

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -59,7 +59,12 @@
 %%
 %% `handler_id' must be unique, if another handler with the same ID already exists the
 %% `{error, already_exists}' tuple is returned.
+%%
 %% See {@link execute/3} to learn how the handlers are invoked.
+%%
+%% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
+%% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
+%% to achive maximum performance.
 -spec attach(HandlerId, EventName, Function, Config) -> ok | {error, already_exists} when
       HandlerId :: handler_id(),
       EventName :: event_name(),
@@ -73,6 +78,10 @@ attach(HandlerId, EventName, Function, Config) ->
 %% The handler will be invoked whenever any of the events in the `event_names' list is emitted. Note
 %% that failure of the handler on any of these invokations will detach it from all the events in
 %% `event_name' (the same applies to manual detaching using {@link detach/1}).
+%%
+%% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
+%% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
+%% to achive maximum performance.
 -spec attach_many(HandlerId, [EventName], Function, Config) -> ok | {error, already_exists} when
       HandlerId :: handler_id(),
       EventName :: event_name(),


### PR DESCRIPTION
We've done a bunch of testing of Telemetry performance recently. We measured how many iterations of `:telemetry.execute/3` a process is able to run in a given amount of time. Later, we run the same benchmark while increasing the number of processes. Our hypothesis was that *n* processes would perform *n* times iterations of a single process (so if one process did 100 iterations, two processes would do 200) for *n* smaller than the number of schedulers, and for *n* greater than or equal to the number of iterations would be constant.

However, after running a bunch of tests, it turned out that it's not the case (the machine has4 physical cores):

![speedup vs  n processes](https://user-images.githubusercontent.com/11610769/56300186-c81cc380-6135-11e9-88cf-fbaf20a935aa.png)

The X axis is the number of processes, and the Y axis is the ratio of number of iterations to the number of iterations performed by a single process. As you can see, this does not match the expected behaviour.

In these tests, we used a local anonymous function as an event handler. When we used a global function capture (i.e. `&Mod.fun/4`), the results look like this:

![speedup vs  n processes (1)](https://user-images.githubusercontent.com/11610769/56302117-665e5880-6139-11e9-8333-2456810a0ce2.png)

It turned out, that when anonymous functions are copied into the process heap from ETS, a global reference counter is incremented, which we suspect is the cause of contention. 

I thought that we might add a note about it to the docs :)