### PR TITLE
Test on OTP 22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ workflows:
   build_and_test:
     jobs:
       - telemetry/build_and_test:
+          name: "otp-22"
+          version: "22-alpine"
+          codecov_flag: "otp22"
+      - telemetry/build_and_test:
           name: "otp-21"
           version: "21-alpine"
           codecov_flag: "otp21"


### PR DESCRIPTION
This adds additional job to CircleCI workflow testing Telemetry on OTP 22. The question is: do we want to keep the job for OTP 18?