### PR TITLE
Protect calls to execute

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -27,7 +27,6 @@
 -include_lib("kernel/include/logger.hrl").
 -else.
 -define(LOG_WARNING(Msg, Args), error_logger:warning_msg(Msg, Args)).
--define(LOG_WARNING(Msg), error_logger:warning_msg(Msg)).
 -endif.
 
 
@@ -128,15 +127,7 @@ execute(EventName, Value, Metadata) when is_number(Value) ->
                  "Use a measurement map instead.", []),
     execute(EventName, #{value => Value}, Metadata);
 execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(Metadata) ->
-    Handlers =
-      try
-        telemetry_handler_table:list_for_event(EventName)
-      catch
-        error:badarg ->
-            ?LOG_WARNING("Failed to lookup telemetry handlers. "
-                         "Ensure the telemetry application has been started. "),
-            []
-      end,
+    Handlers = telemetry_handler_table:list_for_event(EventName),
     ApplyFun =
         fun(#handler{id=HandlerId,
                      function=HandlerFunction,

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -17,19 +17,6 @@
 
 -include("telemetry.hrl").
 
--ifdef('OTP_RELEASE').
--include_lib("kernel/include/logger.hrl").
--else.
--define(LOG_ERROR(Msg, Args), error_logger:error_msg(Msg, Args)).
--endif.
-
--ifdef('OTP_RELEASE').
--include_lib("kernel/include/logger.hrl").
--else.
--define(LOG_WARNING(Msg, Args), error_logger:warning_msg(Msg, Args)).
--endif.
-
-
 -type handler_id() :: term().
 -type event_name() :: [atom(), ...].
 -type event_measurements() :: map().

--- a/src/telemetry.hrl
+++ b/src/telemetry.hrl
@@ -8,3 +8,15 @@
 -else.
 -define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(),).
 -endif.
+
+-ifdef('OTP_RELEASE').
+-include_lib("kernel/include/logger.hrl").
+-else.
+-define(LOG_ERROR(Msg, Args), error_logger:error_msg(Msg, Args)).
+-endif.
+
+-ifdef('OTP_RELEASE').
+-include_lib("kernel/include/logger.hrl").
+-else.
+-define(LOG_WARNING(Msg, Args), error_logger:warning_msg(Msg, Args)).
+-endif.

--- a/src/telemetry_handler_table.erl
+++ b/src/telemetry_handler_table.erl
@@ -48,8 +48,8 @@ list_for_event(EventName) ->
         ets:lookup(?MODULE, EventName)
     catch
         error:badarg ->
-            error_logger:warning_msg("Failed to lookup telemetry handlers. "
-                                     "Ensure the telemetry application has been started. "),
+            ?LOG_WARNING("Failed to lookup telemetry handlers. "
+                         "Ensure the telemetry application has been started. ", []),
             []
     end.
 

--- a/src/telemetry_handler_table.erl
+++ b/src/telemetry_handler_table.erl
@@ -44,7 +44,14 @@ delete(HandlerId) ->
 
 -spec list_for_event(telemetry:event_name()) -> [#handler{}].
 list_for_event(EventName) ->
-    ets:lookup(?MODULE, EventName).
+    try
+        ets:lookup(?MODULE, EventName)
+    catch
+        error:badarg ->
+            error_logger:warning_msg("Failed to lookup telemetry handlers. "
+                                     "Ensure the telemetry application has been started. "),
+            []
+    end.
 
 -spec list_by_prefix(telemetry:event_prefix()) -> [#handler{}].
 list_by_prefix(EventPrefix) ->

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -10,7 +10,8 @@ all() ->
      list_handlers, list_for_prefix, detach_on_exception,
      no_execute_detached, no_execute_on_prefix, no_execute_on_specific,
      handler_on_multiple_events, remove_all_handler_on_failure,
-     list_handler_on_many, detach_from_all, old_execute, default_metadata].
+     list_handler_on_many, detach_from_all, old_execute, default_metadata,
+     safe_execute].
 
 init_per_suite(Config) ->
     application:ensure_all_started(telemetry),
@@ -26,6 +27,12 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, Config) ->
     HandlerId = ?config(id, Config),
     telemetry:detach(HandlerId).
+
+% Ensure calling execute is safe even if telemetry app isn't running
+safe_execute(Config) ->
+    application:stop(telemetry),
+    telemetry:execute([event, name], #{}, #{}),
+    application:ensure_all_started(telemetry).
 
 bad_event_names(Config) ->
     HandlerId = ?config(id, Config),

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -11,7 +11,7 @@ all() ->
      no_execute_detached, no_execute_on_prefix, no_execute_on_specific,
      handler_on_multiple_events, remove_all_handler_on_failure,
      list_handler_on_many, detach_from_all, old_execute, default_metadata,
-     safe_execute].
+     off_execute].
 
 init_per_suite(Config) ->
     application:ensure_all_started(telemetry),
@@ -27,12 +27,6 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, Config) ->
     HandlerId = ?config(id, Config),
     telemetry:detach(HandlerId).
-
-% Ensure calling execute is safe even if telemetry app isn't running
-safe_execute(Config) ->
-    application:stop(telemetry),
-    telemetry:execute([event, name], #{}, #{}),
-    application:ensure_all_started(telemetry).
 
 bad_event_names(Config) ->
     HandlerId = ?config(id, Config),
@@ -300,6 +294,11 @@ default_metadata(Config) ->
             ct:fail(missing_echo_event)
     end.
 
+% Ensure calling execute is safe when the telemetry application is off
+off_execute(Config) ->
+    application:stop(telemetry),
+    telemetry:execute([event, name], #{}, #{}),
+    application:ensure_all_started(telemetry).
 
 echo_event(Event, Measurements, Metadata, #{send_to := Pid} = Config) ->
     Pid ! {event, Event, Measurements, Metadata, Config}.


### PR DESCRIPTION
This PR wraps the calls to `telemetry:execute` to protect against crashes if the `telemetry` app hasn't started & the ETS tables don't exist.

I haven't written much erlang so all feedback is welcome

fixes #53 