### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ event depending on whether the provided function successfully executed or raised
 the `telemetry:span/3` function leverages the `telemetry:execute/3` function, so all the same usage patterns
 apply. If an exception does occur, an `EventPrefix ++ [exception]` event will be emitted and the caught error
 will be re-raised.
-key 
 
 The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is 
 derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]` 
 events, the measurements will contain a key called `duration`, whose value is derived by calling 
-`erlang:monotonic_time() - start_monotonic_time`. Both `system_time` and `duration` represent time as native units.
+`erlang:monotonic_time() - start_monotonic_time`. Both `system_time` and `duration` represent time as 
+native units.
 
 To create span events, you would do something like so:
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ key
 
 The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is 
 derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]` 
-events a key called `duration` which is derived by calling `erlang:monotonic_time() - start_monotonic_time`. 
-Both `system_time` and `duration` represent time as native units.
+events, the measurements will contain a key called `duration`, whose value is derived by calling 
+`erlang:monotonic_time() - start_monotonic_time`. Both `system_time` and `duration` represent time as native units.
 
 To create span events, you would do something like so:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ will be re-raised.
 The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is 
 derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]` 
 events, the measurements will contain a key called `duration`, whose value is derived by calling 
-`erlang:monotonic_time() - start_monotonic_time`. Both `system_time` and `duration` represent time as 
+`erlang:monotonic_time() - StartMonotonicTime`. Both `system_time` and `duration` represent time as 
 native units.
 
 To create span events, you would do something like so:

--- a/README.md
+++ b/README.md
@@ -102,9 +102,15 @@ cases across whole ecosystem.
 In order to provide uniform events that capture the start and end of discrete events, it is recommended
 that you use the `telemetry:span/3` call. This function will generate a start event and a stop or exception
 event depending on whether the provided function successfully executed or raised and error. Under the hood,
-the `telemetry:span/3` function leverages the `telemetry:execute/3` function, so all the same usages patterns
+the `telemetry:span/3` function leverages the `telemetry:execute/3` function, so all the same usage patterns
 apply. If an exception does occur, an `EventPrefix ++ [exception]` event will be emitted and the caught error
 will be re-raised.
+key 
+
+The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is 
+derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]` 
+events a key called `duration` which is derived by calling `erlang:monotonic_time() - start_monotonic_time`. 
+Both `system_time` and `duration` represent time as native units.
 
 To create span events, you would do something like so:
 


### PR DESCRIPTION
Mention `duration` and `system_time` measurements added to `span` events in the documentation.