### PR TITLE
add a note about using convert_time_unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ events, the measurements will contain a key called `duration`, whose value is de
 `erlang:monotonic_time() - StartMonotonicTime`. Both `system_time` and `duration` represent time as
 native units.
 
+To convert the duration from native units you can use:
+
+```elixir
+milliseconds = System.convert_time_unit(duration, :native, :millisecond)
+```
+
 To create span events, you would do something like so:
 
 In Elixir:


### PR DESCRIPTION
I wrote an event handler for a span and was surprised by the results in the duration field. I hadn't worked with native units before, and wanted to provide a little more context on how you might use them.