### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0](https://github.com/elixir-telemetry/telemetry/tree/v0.4.2)
+## [1.0.0](https://github.com/elixir-telemetry/telemetry/tree/v1.0.0)
 
 There are no changes in the 1.0.0 release - it marks the stability of the API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 There are no changes in the 1.0.0 release - it marks the stability of the API.
 
+## [0.4.3](https://github.com/elixir-telemetry/telemetry/tree/v0.4.3)
+
+This release improves the `telemetry:span/3` function by adding the `telemetry_span_context` metadata
+to all span events. The new metadata enables correlating span events that belong to the same span.
+
+### Added
+
+- Added `telemetry_span_context` metadata to all events emitted by `telemetry:span/3`.
+
 ## [0.4.2](https://github.com/elixir-telemetry/telemetry/tree/v0.4.2)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.3](https://github.com/elixir-telemetry/telemetry/tree/v0.4.3)
+## [1.0.0](https://github.com/elixir-telemetry/telemetry/tree/v0.4.2)
 
-This release improves the `telemetry:span/3` function by adding the `telemetry_span_context` metadata
-to all span events. The new metadata enables correlating span events that belong to the same span.
-
-### Added
-
-- Added `telemetry_span_context` metadata to all events emitted by `telemetry:span/3`.
+There are no changes in the 1.0.0 release - it marks the stability of the API.
 
 ## [0.4.2](https://github.com/elixir-telemetry/telemetry/tree/v0.4.2)
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ your dependencies in `mix.exs`:
 ```elixir
 defp deps() do
   [
-    {:telemetry, "~> 0.4"}
+    {:telemetry, "~> 1.0"}
   ]
 end
 ```
@@ -229,7 +229,7 @@ end
 or `rebar.config`:
 
 ```erlang
-{deps, [{telemetry, "~> 0.4"}]}.
+{deps, [{telemetry, "~> 1.0"}]}.
 ```
 
 ## Copyright and License

--- a/docs.sh
+++ b/docs.sh
@@ -9,7 +9,7 @@ set -e
 
 rebar3 compile
 rebar3 as docs edoc
-version=0.4.3
+version=1.0.0
 ex_doc "telemetry" $version "_build/default/lib/telemetry/ebin" \
   --source-ref v${version} \
   --config docs.config $@


### PR DESCRIPTION
The new version of rebar3 handles dependency versions with an `or` (see https://github.com/erlang/rebar3/pull/2370), so dependencies relying on telemetry will be able to use `~> 0.4 or ~> 1.0`. 

(cc'ing @tsloughter to make sure that I haven't got ☝️ wrong, but it seems to be working with rebar3 3.14.4 in my tests).

We can safely mark 1.0.0 now!

Closes #69 