### PR TITLE
Add support for span context

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -336,5 +336,5 @@ assert_event_name(Term) ->
     erlang:error(badarg, Term).
 
 -spec merge_ctx(event_metadata(), any()) -> event_metadata().
-merge_ctx(Metadata, Ctx) ->
-    maps:merge(#{telemetry_span_context => Ctx}, Metadata).
+merge_ctx(#{telemetry_span_context := _} = Metadata, _Ctx) -> Metadata;
+merge_ctx(Metadata, Ctx) -> Metadata#{telemetry_span_context => Ctx}.

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -159,7 +159,8 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %% A default span context is added to event metadata under the `telemetry_span_context` key if none is provided by
 %% the user in the `StartMetadata`. This context is useful for tracing libraries to identify unique
 %% executions of span events within a process to match start, stop, and exception events. Users
-%% should ensure this value is unique within the context of a process at a minimum if overriding this key.
+%% should ensure this value is unique within the context of a process at a minimum if overriding this key and
+%% that the same value is provided to bot `StartMetadata` and `StopMetadata`.
 %%
 %% For `telemetry' events denoting the <strong>start</strong> of a larger event, the following data is provided:
 %% <p>

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -156,6 +156,11 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %% of another process, then none or only part of those events would be emitted.
 %% Below is a breakdown of the measurements and metadata associated with each individual event.
 %%
+%% A default span context is added to event metadata under the `ctx` key if none is provided by
+%% the user in the `StartMetadata`. This context is useful for tracing libraries to identify unique
+%% executions of span events within a process to match start, stop, and exception events. Users
+%% should ensure this value is unique within the context of a process at a minimum if overriding this key.
+%%
 %% For `telemetry' events denoting the <strong>start</strong> of a larger event, the following data is provided:
 %% <p>
 %% <ul>
@@ -179,7 +184,8 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %% Metadata:
 %% ```
 %% #{
-%%   % User defined metadata
+%%   % User defined metadata,
+%%   ctx => {EventPrefix, non_neg_integer()}
 %%   ...
 %% }
 %% '''
@@ -214,6 +220,7 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %%   % but not necessarily an exception. Additional user defined metadata can
 %%   % also be added here.
 %%   error => term(),
+%%   ctx => {EventPrefix, non_neg_integer()}
 %%   ...
 %% }
 %% '''
@@ -247,6 +254,7 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %%   kind => throw | error | exit,
 %%   reason => term(),
 %%   stacktrace => list(),
+%%   ctx => {EventPrefix, integer},
 %%   % User defined metadata from the start event
 %%    ...
 %% }
@@ -257,18 +265,19 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 -spec span(event_prefix(), event_metadata(), span_function()) -> span_result().
 span(EventPrefix, StartMetadata, SpanFunction) ->
     StartTime = erlang:monotonic_time(),
-    execute(EventPrefix ++ [start], #{system_time => erlang:system_time()}, StartMetadata),
+    DefaultCtx = default_ctx(EventPrefix),
+    execute(EventPrefix ++ [start], #{system_time => erlang:system_time()}, merge_ctx(StartMetadata, DefaultCtx)),
 
     try {_, #{}} = SpanFunction() of
       {Result, StopMetadata} ->
-          execute(EventPrefix ++ [stop], #{duration => erlang:monotonic_time() - StartTime}, StopMetadata),
+          execute(EventPrefix ++ [stop], #{duration => erlang:monotonic_time() - StartTime}, merge_ctx(StopMetadata, DefaultCtx)),
           Result
     catch
         ?WITH_STACKTRACE(Class, Reason, Stacktrace)
             execute(
                 EventPrefix ++ [exception],
                 #{duration => erlang:monotonic_time() - StartTime},
-                StartMetadata#{kind => Class, reason => Reason, stacktrace => Stacktrace}
+                merge_ctx(StartMetadata#{kind => Class, reason => Reason, stacktrace => Stacktrace}, DefaultCtx)
             ),
             erlang:raise(Class, Reason, Stacktrace)
     end.
@@ -325,3 +334,19 @@ assert_event_name([_ | _] = List) ->
     end;
 assert_event_name(Term) ->
     erlang:error(badarg, Term).
+
+-spec default_ctx(event_prefix()) -> {event_prefix(), non_neg_integer()}.
+default_ctx(EventPrefix) ->
+    case erlang:get({telemetry, ctx_counter, EventPrefix}) of
+        undefined ->
+            erlang:put({telemetry, ctx_counter, EventPrefix}, 1),
+            {EventPrefix, 1};
+        Count when erlang:is_integer(Count) ->
+            Next = Count + 1,
+            erlang:put({telemetry, ctx_counter, EventPrefix}, Next),
+            {EventPrefix, Next}
+    end.
+
+-spec merge_ctx(event_metadata(), any()) -> event_metadata().
+merge_ctx(Metadata, Ctx) ->
+    maps:merge(#{ctx => Ctx}, Metadata).

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -160,7 +160,7 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %% the user in the `StartMetadata`. This context is useful for tracing libraries to identify unique
 %% executions of span events within a process to match start, stop, and exception events. Users
 %% should ensure this value is unique within the context of a process at a minimum if overriding this key and
-%% that the same value is provided to bot `StartMetadata` and `StopMetadata`.
+%% that the same value is provided to both `StartMetadata` and `StopMetadata`.
 %%
 %% For `telemetry' events denoting the <strong>start</strong> of a larger event, the following data is provided:
 %% <p>


### PR DESCRIPTION
This adds support for span contexts so that tracing libraries can correlate unique event executions within a process for the same span. A default context is automatically added to event metadata if none is present.

The default context consists of a tuple with the event prefix and a monotonically increasing integer, e.g. `{EventPrefix, 1}`. If the consumer needs something more unique, this value can be combined with other data at the time of execution for storage in something like ets, e.g. `{pid(), {EventPrefix, 1}}`.

Closes #74 