### PR TITLE
Update Erlang on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["23.2.1", "22.3.4.9", "21.3.8.17", "20.3.8.26"]
+        otp_version: ["24.0", "23.3.1", "22.3.4.9", "21.3.8.17"]
         os: [ubuntu-latest]
     env:
       OTP_VERSION: ${{ matrix.otp_version }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        otp_version: ["23.2.1", "22.3.4.9", "21.3.8.17", "20.3.8.26"]
+        otp_version: ["24.0", "23.3.1", "22.3.4.9", "21.3.8.17"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Test with OTP 24 and update patch version numbers for older releases.