### PR TITLE
Generate docs with ExDoc

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,7 +1,0 @@
-@copyright 2018 Chris McCord and Erlang Solutions
-@version 0.4.3
-@title Telemetry
-@doc Telemetry is a dynamic dispatching library for metrics and instrumentations.
-It is lightweight, small and can be used in any Erlang or Elixir project.
-
-See the {@link telemetry} module documentation to learn the API.

--- a/docs.exs
+++ b/docs.exs
@@ -1,0 +1,6 @@
+[
+  source_url: "https://github.com/beam-telemetry/telemetry",
+  extras: ["README.md", "CHANGELOG.md", "LICENSE", "NOTICE"],
+  main: "readme",
+  proglang: :erlang
+]

--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Setup:
+#
+#     mix escript.install github elixir-lang/ex_doc
+#     asdf install erlang 24.0.2
+#     asdf local erlang 24.0.2
+
+rebar3 compile
+rebar3 as docs edoc
+version=0.4.3
+ex_doc "telemetry" $version "_build/default/lib/telemetry/ebin" \
+  --source-ref v${version} \
+  --config docs.exs $@

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,9 @@
             {covertool, [{coverdata_files, ["ct.coverdata"]}]}
     ]},
     {docs, [{edoc_opts, [{preprocess, true},
-                         {title, "Telemetry v0.4.3"}]}
+                         {doclet, edoc_doclet_chunks},
+                         {layout, edoc_layout_chunks},
+                         {dir, "_build/default/lib/telemetry/doc"}]}
     ]}
 ]}.
 

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -155,19 +155,20 @@ execute(EventName, Measurements, Metadata) when is_map(Measurements) and is_map(
 %% However, note that in case the current processes crashes due to an exit signal
 %% of another process, then none or only part of those events would be emitted.
 %% Below is a breakdown of the measurements and metadata associated with each individual event.
-%% 
-%% When providing `StartMetadata` and `StopMetadata`, these values will be sent independently to `start` and
-%% `stop` events. If an exception occurs, exception metadata will be merged onto the `StartMetadata`. In general,
-%% `StopMetadata` should only provide values that are additive to `StartMetadata` so that handlers, such as those
-%% used for metrics, can rely entirely on the `stop` event.
 %%
-%% A default span context is added to event metadata under the `telemetry_span_context` key if none is provided by
-%% the user in the `StartMetadata`. This context is useful for tracing libraries to identify unique
+%% When providing `StartMetadata' and `StopMetadata', these values will be sent independently to `start' and
+%% `stop' events. If an exception occurs, exception metadata will be merged onto the `StartMetadata'. In general,
+%% `StopMetadata' should only provide values that are additive to `StartMetadata' so that handlers, such as those
+%% used for metrics, can rely entirely on the `stop' event.
+%%
+%% A default span context is added to event metadata under the `telemetry_span_context' key if none is provided by
+%% the user in the `StartMetadata'. This context is useful for tracing libraries to identify unique
 %% executions of span events within a process to match start, stop, and exception events. Users
 %% should ensure this value is unique within the context of a process at a minimum if overriding this key and
-%% that the same value is provided to both `StartMetadata` and `StopMetadata`.
+%% that the same value is provided to both `StartMetadata' and `StopMetadata'.
 %%
-%% For `telemetry` events denoting the <strong>start</strong> of a larger event, the following data is provided:
+%% For `telemetry' events denoting the <strong>start</strong> of a larger event, the following data is provided:
+%%
 %% <p>
 %% <ul>
 %% <li>


### PR DESCRIPTION
Our Erlang integration in ExDoc is still in progress, see https://github.com/elixir-lang/ex_doc/issues/1333, but I think it is good enough to generate docs for Telemetry. If you find any bugs please feel free to comment here or on that issue.

Demo: http://wojtekmach.pl/docs/telemetry

