### PR TITLE
Revert vsn change

### DIFF
--- a/src/telemetry.app.src
+++ b/src/telemetry.app.src
@@ -1,6 +1,6 @@
 {application, telemetry,
  [{description, "Dynamic dispatching library for metrics and instrumentations"},
-  {vsn, "1.0.0"},
+  {vsn, "git"},
   {registered, []},
   {mod, {telemetry_app, []}},
   {applications,


### PR DESCRIPTION
It is ok to keep `{vsn, "git"}`. I accidentally committed when trying to
publish docs.

For posterity, when publishing docs, don't do it from the main branch.
Do it from the tag. Then it seems to work ok.

See https://github.com/erlef/rebar3_hex/issues/252

Sorry for noise!