### PR TITLE
Hide report_cb/1 from docs

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -361,7 +361,7 @@ assert_event_name(Term) ->
 merge_ctx(#{telemetry_span_context := _} = Metadata, _Ctx) -> Metadata;
 merge_ctx(Metadata, Ctx) -> Metadata#{telemetry_span_context => Ctx}.
 
-%% @hidden
+%% @private
 report_cb(#{handler_id := Id}) ->
     {"Function passed as a handler with ID ~w is local function.\n"
      "This mean that it is either anonymous function or capture of function "


### PR DESCRIPTION
for posterity, with this code:

    -module(foo).
    -export([f1/0]).

    %% @hidden
    f1() -> ok.

we end up with the following chunk:

    {docs_v1,[{file,"foo.erl"},{location,1}],
             erlang,<<"application/erlang+html">>,none,#{},
             [{{function,f1,0},
               [{file,"foo.erl"},{location,5}],
               [<<"f1()">>],
               none,#{}}]}

note the function gets the doc `none`.

when we switch `@hidden` to `@private`:

    {docs_v1,[{file,"foo.erl"},{location,1}],
             erlang,<<"application/erlang+html">>,none,#{},
             [{{function,f1,0},
               [{file,"foo.erl"},{location,5}],
               [<<"f1()">>],
               hidden,#{}}]}

we get what we want, `hidden`.
