### PR TITLE
Add monotonic_time to span measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ will be re-raised.
 The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is
 derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]`
 events, the measurements will contain a key called `duration`, whose value is derived by calling
-`erlang:monotonic_time() - StartMonotonicTime`. ALl events include a `monotonic_time` measurements too.
+`erlang:monotonic_time() - StartMonotonicTime`. All events include a `monotonic_time` measurements too.
 All of them represent time as native units.
 
 To convert the duration from native units you can use:

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ will be re-raised.
 The measurements for the `EventPrefix ++ [start]` event will contain a key called `system_time` which is
 derived by calling `erlang:system_time()`. For `EventPrefix ++ [stop]` and `EventPrefix ++ [exception]`
 events, the measurements will contain a key called `duration`, whose value is derived by calling
-`erlang:monotonic_time() - StartMonotonicTime`. Both `system_time` and `duration` represent time as
-native units.
+`erlang:monotonic_time() - StartMonotonicTime`. ALl events include a `monotonic_time` measurements too.
+All of them represent time as native units.
 
 To convert the duration from native units you can use:
 

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -313,14 +313,14 @@ invoke_successful_span_handlers(Config) ->
 
     receive
         {event, StartEvent, StartMeasurements, StartMetadata, HandlerConfig} ->
-          ?assertEqual([system_time], maps:keys(StartMeasurements))
+          ?assertEqual([monotonic_time, system_time], maps:keys(StartMeasurements))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end,
 
     receive
         {event, StopEvent, StopMeasurements, StopMetadata, HandlerConfig} ->
-          ?assertEqual([duration], maps:keys(StopMeasurements))
+          ?assertEqual([duration, monotonic_time], maps:keys(StopMeasurements))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end.
@@ -349,14 +349,14 @@ invoke_exception_span_handlers(Config) ->
 
     receive
         {event, StartEvent, StartMeasurements, StartMetadata, HandlerConfig} ->
-          ?assertEqual([system_time], maps:keys(StartMeasurements))
+          ?assertEqual([monotonic_time, system_time], maps:keys(StartMeasurements))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end,
 
     receive
         {event, ExceptionEvent, StopMeasurements, ExceptionMetadata, HandlerConfig} ->
-          ?assertEqual([duration], maps:keys(StopMeasurements)),
+          ?assertEqual([duration, monotonic_time], maps:keys(StopMeasurements)),
           ?assertEqual([kind, reason, some, stacktrace, telemetry_span_context], lists:sort(maps:keys(ExceptionMetadata)))
     after
         1000 -> ct:fail(timeout_receive_echo)


### PR DESCRIPTION
We did not add this originally because we said we were waiting for a use case. Well, the use case has arrived: we are using telemetry events to measure the idle time (the time between the last stop and the next start event). :) This helps us do that without recomputing the monotonic times. In terms of costs, the added costs here are negligent (1 word extra in the map values tuple).