### PR TITLE
Use SPDX ID for licenses in mixfile

### DIFF
--- a/src/telemetry.app.src
+++ b/src/telemetry.app.src
@@ -10,7 +10,7 @@
   {env,[]},
   {modules, []},
 
-  {licenses, ["Apache 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {links, [{"Github", "https://github.com/beam-telemetry/telemetry"}]},
   {doc, "doc"}
  ]}.


### PR DESCRIPTION
Hex.pm recommends this, and it helps tools identify exactly which license this project is released under.