### PR TITLE
Post 1.1.0 updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 # Steps for publishing new version
 
 1. Update version in `src/telemetry.app.src`
-2. Run `rebar3 hex publish`
+2. Run `rebar3 hex publish` (requires https://hexdocs.pm/rebar3_hex)
 3. Run `rebar3 hex publish docs` (requires https://hexdocs.pm/rebar3_ex_doc)

--- a/src/telemetry.app.src
+++ b/src/telemetry.app.src
@@ -12,5 +12,6 @@
 
   {licenses, ["Apache-2.0"]},
   {links, [{"Github", "https://github.com/beam-telemetry/telemetry"}]},
-  {doc, "doc"}
+  {doc, "doc"},
+  {include_files, ["mix.exs"]}
  ]}.


### PR DESCRIPTION
- Adds a link to the hex plugin.
- Adds mix.exs to the extra files that must be included in the published package (1.1.0 already shipped with this).