### PR TITLE
Introduce `attach/5` and `attach_many/5`

### DIFF
--- a/src/telemetry.hrl
+++ b/src/telemetry.hrl
@@ -1,7 +1,8 @@
 -record(handler, {id :: telemetry:handler_id() | '_',
                   event_name :: telemetry:event_name() | '_',
                   function   :: telemetry:handler_function() | '_',
-                  config     :: telemetry:handler_config() | '_'}).
+                  config     :: telemetry:handler_config() | '_',
+                  options    :: telemetry:handler_options() | '_'}).
 
 -ifdef('OTP_RELEASE').
 -define(WITH_STACKTRACE(T, R, S), T:R:S ->).


### PR DESCRIPTION
The new functions take the fifth argument, which is a map of options,
and check for `durable` being set to `true` when handling exceptions. If
`true` value is found, the handler is never being detached, on either
first or sequential failures.

Implements durable event handlers as discussed in #106