### PR TITLE
Add telemetry_test

### DIFF
--- a/src/telemetry_test.erl
+++ b/src/telemetry_test.erl
@@ -1,0 +1,39 @@
+%%%-------------------------------------------------------------------
+%% @doc Functions for testing execution of Telemetry events.
+%%
+%% Testing that the correct Telemetry events are emitted with the
+%% right measurements and metadata is essential for library authors.
+%% It helps to maintain stable APIs and avoid accidental changes
+%% to events.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(telemetry_test).
+
+-export([attach_message_handlers/3]).
+
+%% @doc Attaches a "message" handler to the given events.
+%%
+%% `handler_id` must be unique and is used as the handler ID.
+%%
+%% The attached handler sends a message to `destination_pid` every time it handles one of the
+%% events in `events`. The function returns a reference that you can use to make sure that
+%% messages come from this handler. The shape of messages sent to `destination_pid` is:
+%%
+%% ```
+%% {Event, Ref, Measurements, Metadata}
+%% '''
+%%
+%% You can detach this event with {link telemetry:detach/1}.
+-spec attach_message_handlers(HandlerID, DestinationPID, Events) -> reference() when
+    HandlerID :: telemetry:handler_id(),
+    DestinationPID :: pid(),
+    Events :: [telemetry:event_name(), ...].
+attach_message_handlers(HandlerID, DestPID, Events) when is_pid(DestPID) and is_list(Events) ->
+    Ref = make_ref(),
+    Config = #{dest_pid => DestPID, ref => Ref},
+    telemetry:attach_many(HandlerID, Events, fun handle_event/4, Config),
+    Ref.
+
+handle_event(Event, Measurements, Metadata, #{dest_pid := DestPID, ref := Ref}) ->
+    DestPID ! {Event, Ref, Measurements, Metadata}.

--- a/src/telemetry_test.erl
+++ b/src/telemetry_test.erl
@@ -25,6 +25,27 @@
 %% {Event, Ref, Measurements, Metadata}
 %% '''
 %%
+%% For example, in Erlang a test could look like this:
+%%
+%% ```
+%% Ref = telemetry_test:attach_event_handlers(self(), [[some, event]]),
+%% function_that_emits_the_event(),
+%% receive
+%%     {[some, event], Ref, #{measurement := _}, #{meta := _}} ->
+%%         telemetry:detach(Ref)
+%% after 1000 ->
+%%     ct:fail(timeout_receive_attach_event_handlers)
+%% end.
+%% '''
+%%
+%% In Elixir, a similar test would look like this:
+%%
+%% ```
+%% ref = :telemetry.attach_event_handlers(self(), [[:some, :event]])
+%% function_that_emits_the_event()
+%% assert_received {[:some, :event], ^ref, %{measurement: _}, %{meta: _}}
+%% '''
+%%
 -spec attach_event_handlers(DestinationPID, Events) -> reference() when
     DestinationPID :: pid(),
     Events :: [telemetry:event_name(), ...].

--- a/src/telemetry_test.erl
+++ b/src/telemetry_test.erl
@@ -10,7 +10,7 @@
 
 -module(telemetry_test).
 
--export([attach_message_handlers/3]).
+-export([attach_event_handlers/2]).
 
 %% @doc Attaches a "message" handler to the given events.
 %%
@@ -25,15 +25,15 @@
 %% '''
 %%
 %% You can detach this event with {link telemetry:detach/1}.
--spec attach_message_handlers(HandlerID, DestinationPID, Events) -> reference() when
-    HandlerID :: telemetry:handler_id(),
+-spec attach_event_handlers(DestinationPID, Events) -> {telemetry:handler_id(), reference()} when
     DestinationPID :: pid(),
     Events :: [telemetry:event_name(), ...].
-attach_message_handlers(HandlerID, DestPID, Events) when is_pid(DestPID) and is_list(Events) ->
+attach_event_handlers(DestPID, Events) when is_pid(DestPID) and is_list(Events) ->
     Ref = make_ref(),
+    HandlerId = crypto:strong_rand_bytes(16),
     Config = #{dest_pid => DestPID, ref => Ref},
-    telemetry:attach_many(HandlerID, Events, fun handle_event/4, Config),
-    Ref.
+    telemetry:attach_many(HandlerId, Events, fun handle_event/4, Config),
+    {HandlerId, Ref}.
 
 handle_event(Event, Measurements, Metadata, #{dest_pid := DestPID, ref := Ref}) ->
     DestPID ! {Event, Ref, Measurements, Metadata}.

--- a/test/telemetry_test_SUITE.erl
+++ b/test/telemetry_test_SUITE.erl
@@ -23,13 +23,13 @@ end_per_testcase(_, _Config) ->
 
 %% attach_event_handlers/2 works correctly.
 simple_message(_Config) ->
-    {HandlerId, Ref} = telemetry_test:attach_event_handlers(self(), [[some, event]]),
+    Ref = telemetry_test:attach_event_handlers(self(), [[some, event]]),
 
     telemetry:execute([some, event], #{measurement => 1}, #{meta => 2}),
 
     receive
         {[some, event], Ref, #{measurement := 1}, #{meta := 2}} ->
-            telemetry:detach(HandlerId)
+            telemetry:detach(Ref)
     after 1000 ->
         ct:fail(timeout_receive_attach_event_handlers)
     end.

--- a/test/telemetry_test_SUITE.erl
+++ b/test/telemetry_test_SUITE.erl
@@ -1,0 +1,38 @@
+-module(telemetry_test_SUITE).
+
+-compile(export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+    [simple_message].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(telemetry),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(telemetry).
+
+init_per_testcase(_, Config) ->
+    HandlerId = crypto:strong_rand_bytes(16),
+    [{id, HandlerId} | Config].
+
+end_per_testcase(_, Config) ->
+    HandlerId = ?config(id, Config),
+    telemetry:detach(HandlerId).
+
+%% attach_message_handlers/3 works correctly.
+simple_message(Config) ->
+    HandlerId = ?config(id, Config),
+    Ref = telemetry_test:attach_message_handlers(HandlerId, self(), [[some, event]]),
+
+    telemetry:execute([some, event], #{measurement => 1}, #{meta => 2}),
+
+    receive
+        {[some, event], Ref, #{measurement := 1}, #{meta := 2}} ->
+            ok
+    after 1000 ->
+        ct:fail(timeout_receive_attach_message_handlers)
+    end.

--- a/test/telemetry_test_SUITE.erl
+++ b/test/telemetry_test_SUITE.erl
@@ -16,23 +16,20 @@ end_per_suite(_Config) ->
     application:stop(telemetry).
 
 init_per_testcase(_, Config) ->
-    HandlerId = crypto:strong_rand_bytes(16),
-    [{id, HandlerId} | Config].
+    Config.
 
-end_per_testcase(_, Config) ->
-    HandlerId = ?config(id, Config),
-    telemetry:detach(HandlerId).
+end_per_testcase(_, _Config) ->
+    ok.
 
-%% attach_message_handlers/3 works correctly.
-simple_message(Config) ->
-    HandlerId = ?config(id, Config),
-    Ref = telemetry_test:attach_message_handlers(HandlerId, self(), [[some, event]]),
+%% attach_event_handlers/2 works correctly.
+simple_message(_Config) ->
+    {HandlerId, Ref} = telemetry_test:attach_event_handlers(self(), [[some, event]]),
 
     telemetry:execute([some, event], #{measurement => 1}, #{meta => 2}),
 
     receive
         {[some, event], Ref, #{measurement := 1}, #{meta := 2}} ->
-            ok
+            telemetry:detach(HandlerId)
     after 1000 ->
-        ct:fail(timeout_receive_attach_message_handlers)
+        ct:fail(timeout_receive_attach_event_handlers)
     end.


### PR DESCRIPTION
Hey friends!

I find myself doing this constantly. I think it would be good to have something built-in just for the sake of inviting people to test their telemetry events 😄 

I threw a PR together since I thought it'd be easier to talk about something concrete, but I’m not attached to API or implementation here.

Thoughts?