### PR TITLE
replace local function capture in telemetry_test

### DIFF
--- a/src/telemetry_test.erl
+++ b/src/telemetry_test.erl
@@ -10,7 +10,7 @@
 
 -module(telemetry_test).
 
--export([attach_event_handlers/2]).
+-export([attach_event_handlers/2, handle_event/4]).
 
 %% @doc Attaches a "message" handler to the given events.
 %%
@@ -52,7 +52,7 @@
 attach_event_handlers(DestPID, Events) when is_pid(DestPID) and is_list(Events) ->
     Ref = make_ref(),
     Config = #{dest_pid => DestPID, ref => Ref},
-    telemetry:attach_many(Ref, Events, fun handle_event/4, Config),
+    telemetry:attach_many(Ref, Events, fun telemetry_test:handle_event/4, Config),
     Ref.
 
 handle_event(Event, Measurements, Metadata, #{dest_pid := DestPID, ref := Ref}) ->


### PR DESCRIPTION
👋 When using telemetry_test in an Elixir project we noticed a good amount of test noise from the use of a local function capture. You can reproduce the noise with the following iex session:

```
iex(1)> Mix.install([:telemetry])
Resolving Hex dependencies...
Dependency resolution completed:
New:
  telemetry 1.2.0
* Getting telemetry (Hex package)
===> Analyzing applications...
===> Compiling telemetry
:ok
iex(2)> :telemetry_test.attach_event_handlers(self(), [[:foo, :bar]])

21:57:50.835 [info]  The function passed as a handler with ID #Reference<0.3695714495.3782213633.90238> is a local function.
This means that it is either an anonymous function or a capture of a function without a module specified. That may cause a performance penalty when calling that handler. For more details see the note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach/4
#Reference<0.3695714495.3782213633.90238>
iex(3)>
```

I think this is all that's needed to resolve the issue, but it's also not obvious to me why `telemetry_test_SUITE` doesn't have the same test output. Let me know if I missed something.