### PR TITLE
small qol update to :telemetry.attach/4 docs

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -56,11 +56,11 @@
 %%
 %% See {@link execute/3} to learn how the handlers are invoked.
 %%
-%% <b>Note:</b> due to how anonymous functions are implemented in the Erlang VM, it is best to use
-%% function captures (i.e. `fun mod:fun/4' in Erlang or `&Mod.fun/4' in Elixir) as event handlers
-%% to achieve maximum performance. In other words, avoid using literal anonymous functions
-%% (`fun(...) -> ... end' or `fn ... -> ... end') or local function captures (`fun handle_event/4'
-%% or `&handle_event/4' ) as event handlers.
+%% `function` must be a 4 arity function. Due to how anonymous functions are implemented 
+%% in the Erlang VM, it is best to use function captures (i.e. `fun mod:fun/4' in Erlang or 
+%% `&Mod.fun/4' in Elixir) as event handlers to achieve maximum performance. In other words,
+%% avoid using literal anonymous functions (`fun(...) -> ... end' or `fn ... -> ... end') or 
+%% local function captures (`fun handle_event/4' or `&handle_event/4' ) as event handlers.
 %%
 %% All the handlers are executed by the process dispatching event. If the function fails (raises,
 %% exits or throws) then the handler is removed and a failure event is emitted.


### PR DESCRIPTION
This has come up a few times for us. It's not always obvious that the function supplied to attach must be `/4`. When supplying something else you get an exception message that also doesn't reveal the problem.

```
iex(2)> :telemetry.attach("test", [:test, :event], fn -> IO.inspect("Hello") end, nil)
** (FunctionClauseError) no function clause matching in :telemetry.attach_many/4

    The following arguments were given to :telemetry.attach_many/4:
        # 1
        "test"

        # 2
        [[:test, :event]]

        # 3
        #Function<43.3316493/0 in :erl_eval.expr/6>

        # 4
        nil

    (telemetry 1.2.1) /Users/egunderson/Library/Caches/mix/installs/elixir-1.14.2-erts-13.1.2/e123f7ef1d039f8d998d1a6a03fb9b81/deps/telemetry/src/telemetry.erl:106: :telemetry.attach_many/4
    iex:2: (file)
```

I'm hoping that adding a slightly more explicit explanation of the function argument in function doc will help some people avoid this confusion in the future.