### PR TITLE
Ability to return extra measurements from :telemetry.span

### DIFF
--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -203,7 +203,7 @@ execute([_ | _] = EventName, Measurements, Metadata) when is_map(Measurements) a
 %% should be available to both `start' and `stop' events need to supplied separately for `StartMetadata' and
 %% `StopMetadata'.
 %%
-%% If `SpanFunction` is returned as `{result, extra_measurements, stop_metadata}`, then a map of extra measurements
+%% If `SpanFunction` returns `{result, extra_measurements, stop_metadata}`, then a map of extra measurements
 %% will be merged with the measurements automatically provided. This is useful if you want to return, for example, 
 %% bytes from an HTTP request. The standard measurements `duration` and `monotonic_time` cannot be overridden.
 %%

--- a/src/telemetry.erl
+++ b/src/telemetry.erl
@@ -205,7 +205,7 @@ execute([_ | _] = EventName, Measurements, Metadata) when is_map(Measurements) a
 %%
 %% If `SpanFunction` is returned as `{result, stop_metadata, extra_measurements}`, then a map of extra measurements
 %% will be merged with the measurements automatically provided. This is useful if you want to return, for example, 
-%% bytes from an HTTP request. The automatic measurements, `duration` and `monotonic_time` cannot be overriden.
+%% bytes from an HTTP request. The standard measurements `duration` and `monotonic_time` cannot be overridden.
 %%
 %% For `telemetry' events denoting the <strong>start</strong> of a larger event, the following data is provided:
 %%

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -336,14 +336,14 @@ invoke_successful_span_handlers(Config) ->
 
     receive
         {event, StartEvent, StartMeasurements, StartMetadata, HandlerConfig} ->
-          ?assertEqual([monotonic_time, system_time], maps:keys(StartMeasurements))
+          ?assertEqual([monotonic_time, system_time], lists:sort(maps:keys(StartMeasurements)))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end,
 
     receive
         {event, StopEvent, StopMeasurements, StopMetadata, HandlerConfig} ->
-          ?assertEqual([duration, monotonic_time], maps:keys(StopMeasurements))
+          ?assertEqual([duration, monotonic_time], lists:sort(maps:keys(StopMeasurements)))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end.
@@ -372,14 +372,14 @@ invoke_exception_span_handlers(Config) ->
 
     receive
         {event, StartEvent, StartMeasurements, StartMetadata, HandlerConfig} ->
-          ?assertEqual([monotonic_time, system_time], maps:keys(StartMeasurements))
+          ?assertEqual([monotonic_time, system_time], lists:sort(maps:keys(StartMeasurements)))
     after
         1000 -> ct:fail(timeout_receive_echo)
     end,
 
     receive
         {event, ExceptionEvent, StopMeasurements, ExceptionMetadata, HandlerConfig} ->
-          ?assertEqual([duration, monotonic_time], maps:keys(StopMeasurements)),
+          ?assertEqual([duration, monotonic_time], lists:sort(maps:keys(StopMeasurements))),
           ?assertEqual([kind, reason, some, stacktrace, telemetry_span_context], lists:sort(maps:keys(ExceptionMetadata)))
     after
         1000 -> ct:fail(timeout_receive_echo)

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -358,7 +358,7 @@ invoke_successful_span_handlers_with_measurements(Config) ->
     StartMetadata = #{some => start_metadata, telemetry_span_context => ctx},
     StopMetadata = #{other => stop_metadata, telemetry_span_context => ctx},
     ExtraMeasurements = #{other_thing => 100},
-    ErrorSpanFunction = fun() -> {ok, StopMetadata, ExtraMeasurements} end,
+    ErrorSpanFunction = fun() -> {ok, ExtraMeasurements, StopMetadata} end,
 
     telemetry:attach_many(HandlerId, [StartEvent, StopEvent], fun ?MODULE:echo_event/4, HandlerConfig),
     telemetry:span(EventPrefix, StartMetadata, ErrorSpanFunction),

--- a/test/telemetry_SUITE.erl
+++ b/test/telemetry_SUITE.erl
@@ -348,6 +348,35 @@ invoke_successful_span_handlers(Config) ->
         1000 -> ct:fail(timeout_receive_echo)
     end.
 
+% Ensure that stop event includes custom measurements if provided
+invoke_successful_span_handlers_with_measurements(Config) ->
+    HandlerId = ?config(id, Config),
+    EventPrefix = [some, action],
+    StartEvent = EventPrefix ++ [start],
+    StopEvent = EventPrefix ++ [stop],
+    HandlerConfig = #{send_to => self()},
+    StartMetadata = #{some => start_metadata, telemetry_span_context => ctx},
+    StopMetadata = #{other => stop_metadata, telemetry_span_context => ctx},
+    ExtraMeasurements = #{other_thing => 100},
+    ErrorSpanFunction = fun() -> {ok, StopMetadata, ExtraMeasurements} end,
+
+    telemetry:attach_many(HandlerId, [StartEvent, StopEvent], fun ?MODULE:echo_event/4, HandlerConfig),
+    telemetry:span(EventPrefix, StartMetadata, ErrorSpanFunction),
+
+    receive
+        {event, StartEvent, StartMeasurements, StartMetadata, HandlerConfig} ->
+          ?assertEqual([monotonic_time, system_time], lists:sort(maps:keys(StartMeasurements)))
+    after
+        1000 -> ct:fail(timeout_receive_echo)
+    end,
+
+    receive
+        {event, StopEvent, StopMeasurements, StopMetadata, HandlerConfig} ->
+          ?assertEqual([duration, monotonic_time, other_thing], lists:sort(maps:keys(StopMeasurements)))
+    after
+        1000 -> ct:fail(timeout_receive_echo)
+    end.
+
 % Ensure that a start and exception event are emitted during an error span call
 invoke_exception_span_handlers(Config) ->
     HandlerId = ?config(id, Config),


### PR DESCRIPTION
This is useful in the case you want all the convenience of `span/3`, but want to return extra measurements, such as the number of bytes in an HTTP request. This is supported by allowing a 3 element version of `SpanFunction`, where the third element is a map of extra measurements. These measurements cannot override the automatic measurements, to prevent mistakes by the user.